### PR TITLE
Add -l --jsonl flag to output JSONL instead of wrapped Array.

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,12 @@ By specifying the `--fold` or `-F` option, csv2json will fold the array of objec
 {"foo": ["1", "2", "3"], "bar": ["a", "b", "c"]}
 ```
 
+### JSONL output
+
+Using the `--jsonl` flag will write out newline-delimited JSON.
+So-called [JSONL or JSON Lines](https://jsonlines.org/). This flag is
+ignored when outputting to files based on names.
+
 ### Output to directory
 
 Using the `--out-dir <dir>` to write the `.json` file to the output dir. It will use the name of the

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -9,6 +9,7 @@ pub const REMOVE_EMPTY_OBJECTS: &str = "remove-empty-objects";
 pub const IN: &str = "in";
 pub const OUT_DIR: &str = "out-dir";
 pub const OUT_NAME: &str = "out-name";
+pub const JSONL: &str = "jsonl";
 pub const BOOLEAN: &str = "boolean";
 pub const NUMERIC: &str = "numeric";
 pub const FOLD: &str = "fold";
@@ -43,6 +44,14 @@ fn configure_app<'a, 'b>() -> App<'a, 'b> {
                 .value_name("TEMPLATE")
                 .help("The template to use for naming multiple output files")
                 .takes_value(true),
+        )
+        .arg(
+            Arg::with_name(JSONL)
+                .short("l")
+                .long(JSONL)
+                .value_name("JSONL")
+                .help("Output JSONL: one line per record")
+                .takes_value(false),
         )
         .arg(
             Arg::with_name(DELIMITER)


### PR DESCRIPTION
This adds a feature that I needed in order to stream JSON easier.

Upstream is archived, so I decided to make a PR against the one fork that had recent additions. Please ignore me if you find this inappropriate!

I'm not confident enough in Rust to refactor the output logic yet. But it could use some refactoring, since I introduce the same block of code in two branches (DRY). Sorry for that.

I could not find integration tests but all `cargo test` remain green. Please direct me to any tests that you want added or changed if any.

I haven't updated the Cargo version number, as I presume this should be done when releasing.